### PR TITLE
Fix `timestamp` attribute of `WakuMessage` in examples

### DIFF
--- a/examples/toy-chat/src/main.rs
+++ b/examples/toy-chat/src/main.rs
@@ -197,7 +197,7 @@ fn run_app<B: Backend>(
                             buff,
                             TOY_CHAT_CONTENT_TOPIC.clone(),
                             1,
-                            Utc::now().timestamp() as usize,
+                            Utc::now().timestamp_nanos() as usize,
                         );
                         if let Err(e) =
                             app.node_handle


### PR DESCRIPTION
Without it messages wouldn't be stored thus not retrievable later on start.

> This attribute MAY contain the Unix epoch time in nanoseconds – https://rfc.vac.dev/spec/14/#message-attributes

![image](https://user-images.githubusercontent.com/13265126/205030502-17330f21-bd1d-44af-9219-10372e4dc3ca.png)
