### PR TITLE
Replace deprecated `chrono::TimeZone::timestamp` for `timestamp_opt` in examples

### DIFF
--- a/examples/toy-chat/src/main.rs
+++ b/examples/toy-chat/src/main.rs
@@ -295,7 +295,7 @@ fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
         .map(|message| {
             let content = vec![Spans::from(Span::raw(format!(
                 "[{} - {}]: {}",
-                message.timestamp().format("%d-%m-%y %H:%M"),
+                message.timestamp().unwrap().format("%d-%m-%y %H:%M"),
                 message.nick(),
                 message.message()
             )))];

--- a/examples/toy-chat/src/protocol.rs
+++ b/examples/toy-chat/src/protocol.rs
@@ -37,6 +37,6 @@ impl Chat2Message {
     }
 
     pub fn timestamp(&self) -> DateTime<Utc> {
-        Utc.timestamp_opt(self.timestamp as i64, 0)
+        Utc.timestamp_opt(self.timestamp as i64, 0).unwrap()
     }
 }

--- a/examples/toy-chat/src/protocol.rs
+++ b/examples/toy-chat/src/protocol.rs
@@ -37,6 +37,6 @@ impl Chat2Message {
     }
 
     pub fn timestamp(&self) -> DateTime<Utc> {
-        Utc.timestamp(self.timestamp as i64, 0)
+        Utc.timestamp_opt(self.timestamp as i64, 0)
     }
 }

--- a/examples/toy-chat/src/protocol.rs
+++ b/examples/toy-chat/src/protocol.rs
@@ -37,6 +37,6 @@ impl Chat2Message {
     }
 
     pub fn timestamp(&self) -> DateTime<Utc> {
-        Utc.timestamp_opt(self.timestamp as i64, 0).unwrap()
+        Utc.timestamp_opt(self.timestamp as i64, 0).expect("Timestamps should not come out of bounds")
     }
 }

--- a/examples/toy-chat/src/protocol.rs
+++ b/examples/toy-chat/src/protocol.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, LocalResult, TimeZone, Utc};
 use once_cell::sync::Lazy;
 use prost::Message;
 use waku_bindings::{Encoding, WakuContentTopic};
@@ -36,7 +36,7 @@ impl Chat2Message {
         &self.nick
     }
 
-    pub fn timestamp(&self) -> DateTime<Utc> {
-        Utc.timestamp_opt(self.timestamp as i64, 0).expect("Timestamps should not come out of bounds")
+    pub fn timestamp(&self) -> LocalResult<DateTime<Utc>> {
+        Utc.timestamp_opt(self.timestamp as i64, 0)
     }
 }


### PR DESCRIPTION
> Deprecated since 0.4.23: use timestamp_opt() instead – https://docs.rs/chrono/latest/chrono/offset/trait.TimeZone.html#method.timestamp