### PR TITLE
ci: codecov and badges

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,43 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+name: Codecov
+
+jobs:
+  test:
+    name: Test
+    env:
+      RUSTFLAGS: -C instrument-coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - uses: actions/setup-go@v3 # we need go to build go-waku
+        with:
+          go-version: '1.19'
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: llvm-tools-preview
+      - uses: actions-rs/cargo@v1
+        continue-on-error: true
+      - run: |
+          cargo install grcov;
+          cargo test --all-features;
+          mkdir /tmp/cov;
+          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: /tmp/cov/
+          name: waku-bindings-codecov
+          fail_ci_if_error: true
+
+

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,6 +33,7 @@ jobs:
           cargo install grcov;
           cargo test --all-features;
           mkdir /tmp/cov;
+          cp target/debug/deps/waku* target/debug/; # Select only waku related bins for codecov
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,9 +31,8 @@ jobs:
         continue-on-error: true
       - run: |
           cargo install grcov;
-          cargo test --all-features;
+          cargo test --all-features -- --ignored;
           mkdir /tmp/cov;
-          cp target/debug/deps/waku* target/debug/; # Select only waku related bins for codecov
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o /tmp/cov/tests.lcov;
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
     tags:
       - v*.*.*
 
-name: CI
+name: Release
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Waku Rust bindings
 
+[![Crates.io][crates-badge]][crates-url]
+[![Documentation][docs-badge]][docs-url]
+[![Build Status][actions-badge]][actions-url]
+[![Codecov Status][codecov-badge]][codecov-url]
+
+[crates-badge]: https://img.shields.io/crates/v/waku-bindings.svg
+[crates-url]: https://crates.io/crates/waku-bindings
+[docs-badge]: https://docs.rs/waku-bindings/badge.svg
+[docs-url]: https://docs.rs/waku-bindings
+[actions-badge]: https://github.com/waku-org/waku-rust-bindings/workflows/CI/badge.svg
+[actions-url]: https://github.com/waku-org/waku-rust-bindings/actions/workflows/main.yml?query=workflow%3ACI+branch%3Amaster
+[codecov-badge]: https://codecov.io/github/waku-org/waku-rust-bindings/branch/main/graph/badge.svg?token=H4CQWRUCUS
+[codecov-url]: https://codecov.io/github/waku-org/waku-rust-bindings
+
 Rust layer on top of [`go-waku`](https://github.com/status-im/go-waku) [c ffi bindings](https://github.com/status-im/go-waku/blob/v0.2.2/library/README.md).
 
 


### PR DESCRIPTION
Using grcov and codecov.io to generate test coverage reports and related badges.
In addition this PR adds crates.io, docs.rs and CI badges.