### PR TITLE
Add helpful annotations.

### DIFF
--- a/waku-bindings/src/general/mod.rs
+++ b/waku-bindings/src/general/mod.rs
@@ -21,7 +21,7 @@ pub type MessageId = String;
 
 /// Protocol identifiers
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ProtocolId {
     Store,
     Lightpush,

--- a/waku-bindings/src/node/peers.rs
+++ b/waku-bindings/src/node/peers.rs
@@ -125,7 +125,7 @@ pub fn waku_peer_count() -> Result<usize> {
 pub type Protocol = String;
 
 /// Peer data from known/connected waku nodes
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WakuPeerData {
     /// Waku peer id


### PR DESCRIPTION
Adding a few annotations that help us at GraphOps more easily build on top of the bindings.