### PR TITLE
fix: default to empty vec if meta field not present

### DIFF
--- a/waku-bindings/src/general/mod.rs
+++ b/waku-bindings/src/general/mod.rs
@@ -89,7 +89,7 @@ pub struct WakuMessage {
     version: WakuMessageVersion,
     /// Unix timestamp in nanoseconds
     timestamp: usize,
-    #[serde(with = "base64_serde")]
+    #[serde(with = "base64_serde", default = "Vec::new")]
     meta: Vec<u8>,
     ephemeral: bool,
     // TODO: implement RLN fields


### PR DESCRIPTION
This change defaults to setting an empty vec for the `meta` field on `WakuMessage` when doing serialisation/deserialisation if none is present. This change is needed because currently we're experiencing a bug where if a message is being constructed like this:
```
let waku_message = WakuMessage::new(
    buff,
    content_topic,
    2,
    Utc::now().timestamp() as usize,
    Vec::new(),
    true,
);
```
on being received, the message will fall into the `Unrecognized` enum variant while performing this validity check:
```
match signal.event() {
  waku::Event::WakuMessage(event) => { ... }
  waku::Event::Unrecognized(data) => Err(WakuHandlingError::InvalidMessage(format!(
            "Unrecognized event!\n {data:?}"
        ))),
  _ => ...
}
```