### PR TITLE
chore: update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,13 @@
 [codecov-badge]: https://codecov.io/github/waku-org/waku-rust-bindings/branch/main/graph/badge.svg?token=H4CQWRUCUS
 [codecov-url]: https://codecov.io/github/waku-org/waku-rust-bindings
 
-Rust layer on top of [`go-waku`](https://github.com/status-im/go-waku) [c ffi bindings](https://github.com/status-im/go-waku/blob/v0.2.2/library/README.md).
+Rust layer on top of [`go-waku`](https://github.com/waku-org/go-waku) [C FFI bindings](https://github.com/waku-org/go-waku/blob/master/library/README.md).
 
 
-## About [Waku](https://waku.org/)
+## About Waku
 
-Waku is the communication layer for Web3. Decentralized communication that scales.
+[Waku](https://waku.org/) is a family of robust and censorship-resistant communication protocols enabling privacy-focused messaging for Web3 applications.
 
 Private. Secure. Runs anywhere.
 
-### What is Waku?
-
-Waku is a suite of privacy-preserving, peer-to-peer messaging protocols.
-
-Waku removes centralized third parties from messaging, enabling private, secure, censorship-free communication with no single point of failure.
-
-Waku provides privacy-preserving capabilities, such as sender anonymity,metadata protection and unlinkability to personally identifiable information.
-
-Waku is designed for generalized messaging, enabling human-to-human, machine-to-machine or hybrid communication.
-
-Waku runs everywhere: desktop, server, including resource-restricted devices, such as mobile devices and browsers.
-How does it work?
-
-The first version of Waku had its origins in the Whisper protocol, with optimizations for scalability and usability. Waku v2 is a complete rewrite. Its relay protocol implements pub/sub over libp2p, and also introduces additional capabilities:
-
-1. Retrieving historical messages for mostly-offline devices. 
-2. Adaptive nodes, allowing for heterogeneous nodes to contribute. 
-3. Bandwidth preservation for light nodes.
-
-This makes it ideal for running a p2p protocol on mobile, or in other similarly resource-restricted environments.
-
-
-
-Read the [Waku docs](https://docs.wakuconnect.dev/)
+Read the [Waku docs](https://docs.waku.org/)


### PR DESCRIPTION
Updates docs references to https://docs.waku.org/

I'll create a follow-up PR in the future to rewrite the README when the Waku Rust docs are released.