### PR TITLE
feat: update go-waku version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,7 +1674,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waku-bindings"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "base64 0.21.0",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen",
 ]

--- a/waku-bindings/Cargo.toml
+++ b/waku-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waku-bindings"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Daniel Sanchez Quiros <danielsq@status.im>"
@@ -26,7 +26,7 @@ serde_json = "1.0"
 sscanf = "0.4"
 smart-default = "0.6"
 url = "2.3"
-waku-sys = { version = "0.2.0", path = "../waku-sys" }
+waku-sys = { version = "0.3.0", path = "../waku-sys" }
 
 [dev-dependencies]
 futures = "0.3.25"

--- a/waku-bindings/src/encrypt.rs
+++ b/waku-bindings/src/encrypt.rs
@@ -1,0 +1,76 @@
+// std
+use std::ffi::CString;
+// crates
+use aes_gcm::{Aes256Gcm, Key};
+use secp256k1::{PublicKey, SecretKey};
+// internal
+use crate::general::{Result, WakuMessage};
+use crate::utils::decode_and_free_response;
+
+/// Optionally sign and encrypt a message using asymmetric encryption
+pub fn waku_encode_asymmetric(
+    message: &WakuMessage,
+    public_key: &PublicKey,
+    signing_key: Option<&SecretKey>,
+) -> Result<WakuMessage> {
+    let pk = hex::encode(public_key.serialize_uncompressed());
+    let sk = signing_key
+        .map(|signing_key| hex::encode(signing_key.secret_bytes()))
+        .unwrap_or_else(String::new);
+    let message_ptr = CString::new(
+        serde_json::to_string(&message)
+            .expect("WakuMessages should always be able to success serializing"),
+    )
+    .expect("CString should build properly from the serialized waku message")
+    .into_raw();
+    let pk_ptr = CString::new(pk)
+        .expect("CString should build properly from hex encoded public key")
+        .into_raw();
+    let sk_ptr = CString::new(sk)
+        .expect("CString should build properly from hex encoded signing key")
+        .into_raw();
+
+    let result_ptr = unsafe {
+        let res = waku_sys::waku_encode_asymmetric(message_ptr, pk_ptr, sk_ptr);
+        drop(CString::from_raw(message_ptr));
+        drop(CString::from_raw(pk_ptr));
+        drop(CString::from_raw(sk_ptr));
+        res
+    };
+
+    decode_and_free_response(result_ptr)
+}
+
+/// Optionally sign and encrypt a message using symmetric encryption
+pub fn waku_encode_symmetric(
+    message: &WakuMessage,
+    symmetric_key: &Key<Aes256Gcm>,
+    signing_key: Option<&SecretKey>,
+) -> Result<WakuMessage> {
+    let symk = hex::encode(symmetric_key.as_slice());
+    let sk = signing_key
+        .map(|signing_key| hex::encode(signing_key.secret_bytes()))
+        .unwrap_or_else(String::new);
+    let message_ptr = CString::new(
+        serde_json::to_string(&message)
+            .expect("WakuMessages should always be able to success serializing"),
+    )
+    .expect("CString should build properly from the serialized waku message")
+    .into_raw();
+    let symk_ptr = CString::new(symk)
+        .expect("CString should build properly from hex encoded symmetric key")
+        .into_raw();
+    let sk_ptr = CString::new(sk)
+        .expect("CString should build properly from hex encoded signing key")
+        .into_raw();
+
+    let result_ptr = unsafe {
+        let res = waku_sys::waku_encode_symmetric(message_ptr, symk_ptr, sk_ptr);
+        drop(CString::from_raw(message_ptr));
+        drop(CString::from_raw(symk_ptr));
+        drop(CString::from_raw(sk_ptr));
+        res
+    };
+
+    decode_and_free_response(result_ptr)
+}

--- a/waku-bindings/src/lib.rs
+++ b/waku-bindings/src/lib.rs
@@ -2,13 +2,14 @@
 //!
 //! Implementation on top of [`waku-bindings`](https://rfc.vac.dev/spec/36/)
 mod decrypt;
+mod encrypt;
 mod events;
 mod general;
 mod node;
 mod utils;
 
 pub use node::{
-    waku_create_content_topic, waku_create_pubsub_topic, waku_dafault_pubsub_topic,
+    waku_create_content_topic, waku_create_pubsub_topic, waku_default_pubsub_topic,
     waku_discv5_update_bootnodes, waku_dns_discovery, waku_new, Aes256Gcm, DnsInfo,
     GossipSubParams, Initialized, Key, Multiaddr, Protocol, PublicKey, Running, SecretKey,
     WakuLogLevel, WakuNodeConfig, WakuNodeHandle, WakuPeerData, WakuPeers, WebsocketParams,

--- a/waku-bindings/src/node/lightpush.rs
+++ b/waku-bindings/src/node/lightpush.rs
@@ -3,12 +3,9 @@
 // std
 use std::ffi::CString;
 use std::time::Duration;
-// crates
-use aes_gcm::{Aes256Gcm, Key};
-use secp256k1::{PublicKey, SecretKey};
 // internal
 use crate::general::{MessageId, PeerId, Result, WakuMessage, WakuPubSubTopic};
-use crate::node::waku_dafault_pubsub_topic;
+use crate::node::waku_default_pubsub_topic;
 use crate::utils::decode_and_free_response;
 
 /// Publish a message using Waku Lightpush
@@ -20,7 +17,7 @@ pub fn waku_lightpush_publish(
     timeout: Option<Duration>,
 ) -> Result<MessageId> {
     let pubsub_topic = pubsub_topic
-        .unwrap_or_else(waku_dafault_pubsub_topic)
+        .unwrap_or_else(waku_default_pubsub_topic)
         .to_string();
     let message_ptr = CString::new(
         serde_json::to_string(&message)
@@ -51,131 +48,6 @@ pub fn waku_lightpush_publish(
         drop(CString::from_raw(message_ptr));
         drop(CString::from_raw(topic_ptr));
         drop(CString::from_raw(peer_id_ptr));
-        res
-    };
-
-    decode_and_free_response(result_ptr)
-}
-
-/// Optionally sign, encrypt using asymmetric encryption and publish a message using Waku Lightpush
-/// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_lightpush_publish_enc_asymmetricchar-messagejson-char-pubsubtopic-char-peerid-char-publickey-char-optionalsigningkey-int-timeoutms)
-pub fn waku_lightpush_publish_encrypt_asymmetric(
-    message: &WakuMessage,
-    pubsub_topic: Option<WakuPubSubTopic>,
-    peer_id: PeerId,
-    public_key: &PublicKey,
-    signing_key: Option<&SecretKey>,
-    timeout: Option<Duration>,
-) -> Result<MessageId> {
-    let pk = hex::encode(public_key.serialize_uncompressed());
-    let sk = signing_key
-        .map(|signing_key| hex::encode(signing_key.secret_bytes()))
-        .unwrap_or_else(String::new);
-    let pubsub_topic = pubsub_topic
-        .unwrap_or_else(waku_dafault_pubsub_topic)
-        .to_string();
-
-    let pubsub_topic_ptr = CString::new(pubsub_topic)
-        .expect("CString should build properly from pubsub topic")
-        .into_raw();
-    let peer_id_ptr = CString::new(peer_id)
-        .expect("CString should build properly from peer id")
-        .into_raw();
-    let pk_ptr = CString::new(pk)
-        .expect("CString should build properly from hex encoded public key")
-        .into_raw();
-    let sk_ptr = CString::new(sk)
-        .expect("CString should build properly from hex encoded signing key")
-        .into_raw();
-    let message_ptr = CString::new(
-        serde_json::to_string(&message)
-            .expect("WakuMessages should always be able to success serializing"),
-    )
-    .expect("CString should build properly from the serialized waku message")
-    .into_raw();
-    let result_ptr = unsafe {
-        let res = waku_sys::waku_lightpush_publish_enc_asymmetric(
-            message_ptr,
-            pubsub_topic_ptr,
-            peer_id_ptr,
-            pk_ptr,
-            sk_ptr,
-            timeout
-                .map(|timeout| {
-                    timeout
-                        .as_millis()
-                        .try_into()
-                        .expect("Duration as milliseconds should fit in a i32")
-                })
-                .unwrap_or(0),
-        );
-        drop(CString::from_raw(message_ptr));
-        drop(CString::from_raw(pubsub_topic_ptr));
-        drop(CString::from_raw(peer_id_ptr));
-        drop(CString::from_raw(pk_ptr));
-        drop(CString::from_raw(sk_ptr));
-        res
-    };
-
-    decode_and_free_response(result_ptr)
-}
-
-/// Optionally sign, encrypt using symmetric encryption and publish a message using Waku Lightpush
-/// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_lightpush_publish_enc_symmetricchar-messagejson-char-pubsubtopic-char-peerid-char-symmetrickey-char-optionalsigningkey-int-timeoutms)
-pub fn waku_lightpush_publish_encrypt_symmetric(
-    message: &WakuMessage,
-    pubsub_topic: Option<WakuPubSubTopic>,
-    peer_id: PeerId,
-    symmetric_key: &Key<Aes256Gcm>,
-    signing_key: Option<&SecretKey>,
-    timeout: Option<Duration>,
-) -> Result<MessageId> {
-    let symk = hex::encode(symmetric_key.as_slice());
-    let sk = signing_key
-        .map(|signing_key| hex::encode(signing_key.secret_bytes()))
-        .unwrap_or_else(String::new);
-    let pubsub_topic = pubsub_topic
-        .unwrap_or_else(waku_dafault_pubsub_topic)
-        .to_string();
-    let message_ptr = CString::new(
-        serde_json::to_string(&message)
-            .expect("WakuMessages should always be able to success serializing"),
-    )
-    .expect("CString should build properly from the serialized waku message")
-    .into_raw();
-    let pubsub_topic_ptr = CString::new(pubsub_topic)
-        .expect("CString should build properly from pubsub topic")
-        .into_raw();
-    let peer_id_ptr = CString::new(peer_id)
-        .expect("CString should build properly from peer id")
-        .into_raw();
-    let symk_ptr = CString::new(symk)
-        .expect("CString should build properly from hex encoded symmetric key")
-        .into_raw();
-    let sk_ptr = CString::new(sk)
-        .expect("CString should build properly from hex encoded signing key")
-        .into_raw();
-    let result_ptr = unsafe {
-        let res = waku_sys::waku_lightpush_publish_enc_symmetric(
-            message_ptr,
-            pubsub_topic_ptr,
-            peer_id_ptr,
-            symk_ptr,
-            sk_ptr,
-            timeout
-                .map(|timeout| {
-                    timeout
-                        .as_millis()
-                        .try_into()
-                        .expect("Duration as milliseconds should fit in a i32")
-                })
-                .unwrap_or(0),
-        );
-        drop(CString::from_raw(message_ptr));
-        drop(CString::from_raw(pubsub_topic_ptr));
-        drop(CString::from_raw(peer_id_ptr));
-        drop(CString::from_raw(symk_ptr));
-        drop(CString::from_raw(sk_ptr));
         res
     };
 

--- a/waku-bindings/src/node/mod.rs
+++ b/waku-bindings/src/node/mod.rs
@@ -27,7 +27,7 @@ use crate::general::{
 pub use config::{GossipSubParams, WakuLogLevel, WakuNodeConfig, WebsocketParams};
 pub use discovery::{waku_discv5_update_bootnodes, waku_dns_discovery, DnsInfo};
 pub use peers::{Protocol, WakuPeerData, WakuPeers};
-pub use relay::{waku_create_content_topic, waku_create_pubsub_topic, waku_dafault_pubsub_topic};
+pub use relay::{waku_create_content_topic, waku_create_pubsub_topic, waku_default_pubsub_topic};
 pub use store::{waku_local_store_query, waku_store_query};
 
 /// Shared flag to check if a waku node is already running in the current process
@@ -159,44 +159,6 @@ impl WakuNodeHandle<Running> {
         relay::waku_relay_publish_message(message, pubsub_topic, timeout)
     }
 
-    /// Optionally sign, encrypt using asymmetric encryption and publish a message using Waku Relay
-    /// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_relay_publish_enc_asymmetricchar-messagejson-char-pubsubtopic-char-publickey-char-optionalsigningkey-int-timeoutms)
-    pub fn relay_publish_encrypt_asymmetric(
-        &self,
-        message: &WakuMessage,
-        pubsub_topic: Option<WakuPubSubTopic>,
-        public_key: &PublicKey,
-        signing_key: Option<&SecretKey>,
-        timeout: Option<Duration>,
-    ) -> Result<MessageId> {
-        relay::waku_relay_publish_encrypt_asymmetric(
-            message,
-            pubsub_topic,
-            public_key,
-            signing_key,
-            timeout,
-        )
-    }
-
-    /// Optionally sign, encrypt using symmetric encryption and publish a message using Waku Relay
-    /// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_relay_publish_enc_symmetricchar-messagejson-char-pubsubtopic-char-symmetrickey-char-optionalsigningkey-int-timeoutms)
-    pub fn relay_publish_encrypt_symmetric(
-        &self,
-        message: &WakuMessage,
-        pubsub_topic: Option<WakuPubSubTopic>,
-        symmetric_key: &Key<Aes256Gcm>,
-        signing_key: Option<&SecretKey>,
-        timeout: Option<Duration>,
-    ) -> Result<MessageId> {
-        relay::waku_relay_publish_encrypt_symmetric(
-            message,
-            pubsub_topic,
-            symmetric_key,
-            signing_key,
-            timeout,
-        )
-    }
-
     /// Determine if there are enough peers to publish a message on a given pubsub topic
     pub fn relay_enough_peers(&self, pubsub_topic: Option<WakuPubSubTopic>) -> Result<bool> {
         relay::waku_enough_peers(pubsub_topic)
@@ -248,48 +210,6 @@ impl WakuNodeHandle<Running> {
         timeout: Option<Duration>,
     ) -> Result<MessageId> {
         lightpush::waku_lightpush_publish(message, pubsub_topic, peer_id, timeout)
-    }
-
-    /// Optionally sign, encrypt using asymmetric encryption and publish a message using Waku Lightpush
-    /// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_lightpush_publish_enc_asymmetricchar-messagejson-char-pubsubtopic-char-peerid-char-publickey-char-optionalsigningkey-int-timeoutms)
-    pub fn lightpush_publish_encrypt_asymmetric(
-        &self,
-        message: &WakuMessage,
-        pubsub_topic: Option<WakuPubSubTopic>,
-        peer_id: PeerId,
-        public_key: &PublicKey,
-        signing_key: Option<&SecretKey>,
-        timeout: Option<Duration>,
-    ) -> Result<MessageId> {
-        lightpush::waku_lightpush_publish_encrypt_asymmetric(
-            message,
-            pubsub_topic,
-            peer_id,
-            public_key,
-            signing_key,
-            timeout,
-        )
-    }
-
-    /// Optionally sign, encrypt using symmetric encryption and publish a message using Waku Lightpush
-    /// As per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_lightpush_publish_enc_symmetricchar-messagejson-char-pubsubtopic-char-peerid-char-symmetrickey-char-optionalsigningkey-int-timeoutms)
-    pub fn lightpush_publish_encrypt_symmetric(
-        &self,
-        message: &WakuMessage,
-        pubsub_topic: Option<WakuPubSubTopic>,
-        peer_id: PeerId,
-        symmetric_key: &Key<Aes256Gcm>,
-        signing_key: Option<&SecretKey>,
-        timeout: Option<Duration>,
-    ) -> Result<MessageId> {
-        lightpush::waku_lightpush_publish_encrypt_symmetric(
-            message,
-            pubsub_topic,
-            peer_id,
-            symmetric_key,
-            signing_key,
-            timeout,
-        )
     }
 
     /// Creates a subscription in a lightnode for messages that matches a content filter and optionally a [`WakuPubSubTopic`](`crate::general::WakuPubSubTopic`)

--- a/waku-sys/Cargo.toml
+++ b/waku-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waku-sys"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Daniel Sanchez Quiros <danielsq@status.im>"

--- a/waku-sys/build.rs
+++ b/waku-sys/build.rs
@@ -39,9 +39,10 @@ fn build_go_waku_lib(go_bin: &str, project_dir: &Path) {
     cmd.env("CGO_ENABLED", "1")
         .arg("build")
         .arg("-buildmode=c-archive")
+        .arg("-tags=gowaku_no_rln")
         .arg("-o")
         .arg(out_dir.join("libgowaku.a"))
-        .arg("./library");
+        .arg("./library/c");
 
     // Setting `GOCACHE=/tmp/` for crates.io job that builds documentation
     // when a crate is being published or updated.


### PR DESCRIPTION
- removes encoding functions from relay and lightpush
- adds `encode_symmetric` and `encode_asymmetric` to `WakuMessage`
- return an error instead of panics in `decode_and_free_response`

May fix #66 