### PR TITLE
refactor: use callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,13 +1674,14 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waku-bindings"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "base64 0.21.0",
  "enr",
  "futures",
  "hex",
+ "libc",
  "multiaddr",
  "once_cell",
  "rand",

--- a/waku-bindings/Cargo.toml
+++ b/waku-bindings/Cargo.toml
@@ -27,6 +27,7 @@ sscanf = "0.4"
 smart-default = "0.6"
 url = "2.3"
 waku-sys = { version = "0.4.0", path = "../waku-sys" }
+libc = "0.2"
 
 [dev-dependencies]
 futures = "0.3.25"

--- a/waku-bindings/src/encrypt.rs
+++ b/waku-bindings/src/encrypt.rs
@@ -2,10 +2,11 @@
 use std::ffi::CString;
 // crates
 use aes_gcm::{Aes256Gcm, Key};
+use libc::*;
 use secp256k1::{PublicKey, SecretKey};
 // internal
 use crate::general::{Result, WakuMessage};
-use crate::utils::decode_and_free_response;
+use crate::utils::{get_trampoline, handle_json_response};
 
 /// Optionally sign and encrypt a message using asymmetric encryption
 pub fn waku_encode_asymmetric(
@@ -16,7 +17,7 @@ pub fn waku_encode_asymmetric(
     let pk = hex::encode(public_key.serialize_uncompressed());
     let sk = signing_key
         .map(|signing_key| hex::encode(signing_key.secret_bytes()))
-        .unwrap_or_else(String::new);
+        .unwrap_or_default();
     let message_ptr = CString::new(
         serde_json::to_string(&message)
             .expect("WakuMessages should always be able to success serializing"),
@@ -30,15 +31,27 @@ pub fn waku_encode_asymmetric(
         .expect("CString should build properly from hex encoded signing key")
         .into_raw();
 
-    let result_ptr = unsafe {
-        let res = waku_sys::waku_encode_asymmetric(message_ptr, pk_ptr, sk_ptr);
+    let mut result: String = Default::default();
+    let result_cb = |v: &str| result = v.to_string();
+    let code = unsafe {
+        let mut closure = result_cb;
+        let cb = get_trampoline(&closure);
+        let out = waku_sys::waku_encode_asymmetric(
+            message_ptr,
+            pk_ptr,
+            sk_ptr,
+            cb,
+            &mut closure as *mut _ as *mut c_void,
+        );
+
         drop(CString::from_raw(message_ptr));
         drop(CString::from_raw(pk_ptr));
         drop(CString::from_raw(sk_ptr));
-        res
+
+        out
     };
 
-    decode_and_free_response(result_ptr)
+    handle_json_response(code, &result)
 }
 
 /// Optionally sign and encrypt a message using symmetric encryption
@@ -50,7 +63,7 @@ pub fn waku_encode_symmetric(
     let symk = hex::encode(symmetric_key.as_slice());
     let sk = signing_key
         .map(|signing_key| hex::encode(signing_key.secret_bytes()))
-        .unwrap_or_else(String::new);
+        .unwrap_or_default();
     let message_ptr = CString::new(
         serde_json::to_string(&message)
             .expect("WakuMessages should always be able to success serializing"),
@@ -64,13 +77,25 @@ pub fn waku_encode_symmetric(
         .expect("CString should build properly from hex encoded signing key")
         .into_raw();
 
-    let result_ptr = unsafe {
-        let res = waku_sys::waku_encode_symmetric(message_ptr, symk_ptr, sk_ptr);
+    let mut result: String = Default::default();
+    let result_cb = |v: &str| result = v.to_string();
+    let code = unsafe {
+        let mut closure = result_cb;
+        let cb = get_trampoline(&closure);
+        let out = waku_sys::waku_encode_symmetric(
+            message_ptr,
+            symk_ptr,
+            sk_ptr,
+            cb,
+            &mut closure as *mut _ as *mut c_void,
+        );
+
         drop(CString::from_raw(message_ptr));
         drop(CString::from_raw(symk_ptr));
         drop(CString::from_raw(sk_ptr));
-        res
+
+        out
     };
 
-    decode_and_free_response(result_ptr)
+    handle_json_response(code, &result)
 }

--- a/waku-bindings/src/events/mod.rs
+++ b/waku-bindings/src/events/mod.rs
@@ -5,7 +5,7 @@
 //! When an event is emitted, this callback will be triggered receiving a [`Signal`]
 
 // std
-use std::ffi::{c_char, CStr};
+use std::ffi::{c_char, c_void, CStr};
 use std::ops::Deref;
 use std::sync::Mutex;
 // crates
@@ -79,7 +79,7 @@ fn set_callback<F: FnMut(Signal) + Send + Sync + 'static>(f: F) {
 
 /// Wrapper callback, it transformst the `*const c_char` into a [`Signal`]
 /// and executes the [`CALLBACK`] funtion with it
-extern "C" fn callback(data: *const c_char) {
+extern "C" fn callback(data: *const c_char, _user_data: *mut c_void) {
     let raw_response = unsafe { CStr::from_ptr(data) }
         .to_str()
         .expect("Not null ptr");
@@ -95,7 +95,7 @@ extern "C" fn callback(data: *const c_char) {
 /// which are used to react to asynchronous events in Waku
 pub fn waku_set_event_callback<F: FnMut(Signal) + Send + Sync + 'static>(f: F) {
     set_callback(f);
-    unsafe { waku_sys::waku_set_event_callback(callback as *mut std::ffi::c_void) };
+    unsafe { waku_sys::waku_set_event_callback(Some(callback)) };
 }
 
 #[cfg(test)]

--- a/waku-bindings/src/general/mod.rs
+++ b/waku-bindings/src/general/mod.rs
@@ -51,28 +51,8 @@ impl Display for ProtocolId {
     }
 }
 
-/// JsonResponse wrapper.
-/// `go-waku` ffi returns this type as a `char *` as per the [specification](https://rfc.vac.dev/spec/36/#jsonresponse-type)
-/// This is internal, as it is better to use rust plain `Result` type.
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum JsonResponse<T> {
-    Result(T),
-    Error(String),
-}
-
 /// Waku response, just a `Result` with an `String` error.
 pub type Result<T> = std::result::Result<T, String>;
-
-/// Convenient we can transform a [`JsonResponse`] into a [`std::result::Result`]
-impl<T> From<JsonResponse<T>> for Result<T> {
-    fn from(response: JsonResponse<T>) -> Self {
-        match response {
-            JsonResponse::Result(t) => Ok(t),
-            JsonResponse::Error(e) => Err(e),
-        }
-    }
-}
 
 // TODO: Properly type and deserialize payload form base64 encoded string
 /// Waku message in JSON format.

--- a/waku-bindings/src/utils.rs
+++ b/waku-bindings/src/utils.rs
@@ -1,25 +1,66 @@
-use crate::general::{JsonResponse, Result};
+use crate::general::Result;
+use core::str::FromStr;
 use serde::de::DeserializeOwned;
-use std::ffi::{c_char, CStr};
+use std::ffi::CStr;
+use waku_sys::WakuCallBack;
+use waku_sys::{RET_ERR, RET_MISSING_CALLBACK, RET_OK};
+pub fn decode<T: DeserializeOwned>(input: &str) -> Result<T> {
+    serde_json::from_str(input)
+        .map_err(|err| format!("could not deserialize waku response: {}", err))
+}
 
-/// Safety: The caller is responsible for ensuring that the pointer is valid for the duration of the call.
-/// This takes a pointer to a C string coming from the waku lib, that data is consumed and then freed using [`waku_sys::waku_utils_free`].
-pub fn decode_and_free_response<T: DeserializeOwned>(response_ptr: *mut c_char) -> Result<T> {
-    let response = unsafe { CStr::from_ptr(response_ptr) }
+unsafe extern "C" fn trampoline<F>(
+    data: *const ::std::os::raw::c_char,
+    user_data: *mut ::std::os::raw::c_void,
+) where
+    F: FnMut(&str),
+{
+    let user_data = &mut *(user_data as *mut F);
+    let response = unsafe { CStr::from_ptr(data) }
         .to_str()
         .map_err(|err| {
             format!(
                 "could not retrieve response from pointer returned by waku: {}",
                 err
             )
-        })?;
+        })
+        .expect("could not retrieve response");
 
-    let response: JsonResponse<T> = serde_json::from_str(response)
-        .map_err(|err| format!("could not deserialize waku JsonResponse: {}", err))?;
+    user_data(response);
+}
 
-    unsafe {
-        waku_sys::waku_utils_free(response_ptr);
+pub fn get_trampoline<F>(_closure: &F) -> WakuCallBack
+where
+    F: FnMut(&str),
+{
+    Some(trampoline::<F>)
+}
+
+pub fn handle_no_response(code: i32, error: &str) -> Result<()> {
+    match code {
+        RET_OK => Ok(()),
+        RET_ERR => Err(format!("waku error: {}", error)),
+        RET_MISSING_CALLBACK => Err("missing callback".to_string()),
+        _ => Err(format!("undefined return code {}", code)),
     }
+}
 
-    response.into()
+pub fn handle_json_response<F: DeserializeOwned>(code: i32, result: &str) -> Result<F> {
+    match code {
+        RET_OK => decode(result),
+        RET_ERR => Err(format!("waku error: {}", result)),
+        RET_MISSING_CALLBACK => Err("missing callback".to_string()),
+        _ => Err(format!("undefined return code {}", code)),
+    }
+}
+
+pub fn handle_response<F: FromStr>(code: i32, result: &str) -> Result<F> {
+    match code {
+        RET_OK => result
+            .parse()
+            .map_err(|_| format!("could not parse value: {}", result)),
+        RET_ERR => Err(format!("waku error: {}", result)),
+        RET_MISSING_CALLBACK => Err("missing callback".to_string()),
+        _ => Err(format!("undefined return code {}", code)),
+    }
 }


### PR DESCRIPTION
To avoid having to call a function to free allocs, go-waku and nwaku are now using callbacks. This PR updates the code to match the new API

- [x] use callbacks for API functions
- [x] remove jsonResponse
- [x] handle deserialization for functions that return json, strings and ints(and booleans)
- [x] ensure tests work