### PR TITLE
Nwaku 2 event callback test

### DIFF
--- a/waku-bindings/src/node/mod.rs
+++ b/waku-bindings/src/node/mod.rs
@@ -90,6 +90,10 @@ impl<Event> WakuNodeHandle<Event> {
         let mut ctx = self.ctx.lock().unwrap();
         events::waku_set_event_callback(ctx.obj_ptr, f)
     }
+
+    pub fn events(&self) -> broadcast::Receiver<Event> {
+        self.events_channel.resubscribe()
+    }
 }
 
 /// Spawn a new Waku node with the given configuration (default configuration if `None` provided)


### PR DESCRIPTION
Use a channel to recieve events instead of allowing setting callbacks. Events is generic, depending on what nwaku returns in the callbacks it can be replace by an specific type or maybe we can create a trait for such events. 
this is just a broad idea as I could not really check if it compiles.