### PR TITLE
refactor: use a enum for handling the responses, and don't ignore the return code

### DIFF
--- a/waku-bindings/src/node/events.rs
+++ b/waku-bindings/src/node/events.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 // internal
 use crate::general::WakuMessage;
 use crate::node::context::WakuNodeContext;
-use crate::utils::get_trampoline;
+use crate::utils::{get_trampoline, LibwakuResponse};
 use crate::MessageId;
 
 /// Waku event
@@ -40,9 +40,15 @@ pub struct WakuMessageEvent {
 /// Register callback to act as event handler and receive application events,
 /// which are used to react to asynchronous events in Waku
 pub fn waku_set_event_callback<F: FnMut(Event) + Send + Sync>(ctx: &WakuNodeContext, mut f: F) {
-    let cb = |v: &str| {
-        let data: Event = serde_json::from_str(v).expect("Parsing event to succeed");
-        f(data);
+    let cb = |response: LibwakuResponse| {
+        match response {
+            LibwakuResponse::Success(v) => {
+                let data: Event =
+                    serde_json::from_str(v.unwrap().as_str()).expect("Parsing event to succeed");
+                f(data);
+            }
+            _ => {} // Do nothing
+        };
     };
 
     unsafe {

--- a/waku-bindings/src/node/mod.rs
+++ b/waku-bindings/src/node/mod.rs
@@ -13,7 +13,7 @@ pub use multiaddr::Multiaddr;
 pub use secp256k1::{PublicKey, SecretKey};
 use std::time::Duration;
 // internal
-use crate::general::{MessageId, Result, WakuMessage};
+use crate::general::{Result, WakuMessage};
 use context::WakuNodeContext;
 
 pub use config::WakuNodeConfig;
@@ -66,7 +66,7 @@ impl WakuNodeHandle {
         message: &WakuMessage,
         pubsub_topic: &String,
         timeout: Option<Duration>,
-    ) -> Result<MessageId> {
+    ) -> Result<()> {
         relay::waku_relay_publish_message(&self.ctx, message, pubsub_topic, timeout)
     }
 

--- a/waku-bindings/src/node/peers.rs
+++ b/waku-bindings/src/node/peers.rs
@@ -9,6 +9,7 @@ use multiaddr::Multiaddr;
 // internal
 use crate::general::Result;
 use crate::node::context::WakuNodeContext;
+use crate::utils::LibwakuResponse;
 use crate::utils::{get_trampoline, handle_no_response};
 
 /// Dial peer using a multiaddress
@@ -25,10 +26,10 @@ pub fn waku_connect(
         .expect("CString should build properly from multiaddress")
         .into_raw();
 
-    let mut error: String = Default::default();
-    let error_cb = |v: &str| error = v.to_string();
+    let mut result: LibwakuResponse = Default::default();
+    let result_cb = |r: LibwakuResponse| result = r;
     let code = unsafe {
-        let mut closure = error_cb;
+        let mut closure = result_cb;
         let cb = get_trampoline(&closure);
         let out = waku_sys::waku_connect(
             ctx.obj_ptr,
@@ -45,5 +46,5 @@ pub fn waku_connect(
         out
     };
 
-    handle_no_response(code, &error)
+    handle_no_response(code, result)
 }


### PR DESCRIPTION
refactor: use a enum for handling the responses, and don't ignore the return code.
In addition to that, i noticed that `waku_relay_publish` is not returning the envelope hash as defined in the bindings. I temporarily removed the code that handles that until that behavior is added in nwaku