### PR TITLE
refactor: node handle constructor and messageId on publish

### DIFF
--- a/waku-bindings/src/general/mod.rs
+++ b/waku-bindings/src/general/mod.rs
@@ -11,8 +11,8 @@ use sscanf::{scanf, RegexRepresentation};
 
 /// Waku message version
 pub type WakuMessageVersion = usize;
-/// Waku message id, hex encoded sha256 digest of the message
-pub type MessageId = String;
+/// Waku message hash, hex encoded sha256 digest of the message
+pub type MessageHash = String;
 
 /// Waku response, just a `Result` with an `String` error.
 pub type Result<T> = std::result::Result<T, String>;

--- a/waku-bindings/src/lib.rs
+++ b/waku-bindings/src/lib.rs
@@ -16,4 +16,6 @@ pub use node::{
     SecretKey, WakuMessageEvent, WakuNodeConfig, WakuNodeHandle,
 };
 
-pub use general::{Encoding, MessageId, Result, WakuContentTopic, WakuMessage, WakuMessageVersion};
+pub use general::{
+    Encoding, MessageHash, Result, WakuContentTopic, WakuMessage, WakuMessageVersion,
+};

--- a/waku-bindings/src/lib.rs
+++ b/waku-bindings/src/lib.rs
@@ -12,7 +12,7 @@ mod utils;
 use rln;
 
 pub use node::{
-    waku_create_content_topic, waku_new, Event, Key, Multiaddr, PublicKey, SecretKey,
+    waku_create_content_topic, Event, Key, Multiaddr, PublicKey, SecretKey,
     WakuMessageEvent, WakuNodeConfig, WakuNodeHandle,
 };
 

--- a/waku-bindings/src/lib.rs
+++ b/waku-bindings/src/lib.rs
@@ -12,8 +12,8 @@ mod utils;
 use rln;
 
 pub use node::{
-    waku_create_content_topic, Event, Key, Multiaddr, PublicKey, SecretKey,
-    WakuMessageEvent, WakuNodeConfig, WakuNodeHandle,
+    waku_create_content_topic, waku_new, Event, Initialized, Key, Multiaddr, PublicKey, Running,
+    SecretKey, WakuMessageEvent, WakuNodeConfig, WakuNodeHandle,
 };
 
 pub use general::{Encoding, MessageId, Result, WakuContentTopic, WakuMessage, WakuMessageVersion};

--- a/waku-bindings/src/node/events.rs
+++ b/waku-bindings/src/node/events.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::general::WakuMessage;
 use crate::node::context::WakuNodeContext;
 use crate::utils::{get_trampoline, LibwakuResponse};
-use crate::MessageId;
+use crate::MessageHash;
 
 /// Waku event
 /// For now just WakuMessage is supported
@@ -31,8 +31,8 @@ pub enum Event {
 pub struct WakuMessageEvent {
     /// The pubsub topic on which the message was received
     pub pubsub_topic: String,
-    /// The message id
-    pub message_id: MessageId,
+    /// The message hash
+    pub message_hash: MessageHash,
     /// The message in [`WakuMessage`] format
     pub waku_message: WakuMessage,
 }
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn deserialize_message_event() {
-        let s = "{\"eventType\":\"message\",\"messageId\":\"0x26ff3d7fbc950ea2158ce62fd76fd745eee0323c9eac23d0713843b0f04ea27c\",\"pubsubTopic\":\"/waku/2/default-waku/proto\",\"wakuMessage\":{\"payload\":\"SGkgZnJvbSDwn6aAIQ==\",\"contentTopic\":\"/toychat/2/huilong/proto\",\"timestamp\":1665580926660}}";
+        let s = "{\"eventType\":\"message\",\"messageHash\":\"0x26ff3d7fbc950ea2158ce62fd76fd745eee0323c9eac23d0713843b0f04ea27c\",\"pubsubTopic\":\"/waku/2/default-waku/proto\",\"wakuMessage\":{\"payload\":\"SGkgZnJvbSDwn6aAIQ==\",\"contentTopic\":\"/toychat/2/huilong/proto\",\"timestamp\":1665580926660}}";
         let evt: Event = serde_json::from_str(s).unwrap();
         assert!(matches!(evt, Event::WakuMessage(_)));
     }

--- a/waku-bindings/src/node/events.rs
+++ b/waku-bindings/src/node/events.rs
@@ -41,13 +41,10 @@ pub struct WakuMessageEvent {
 /// which are used to react to asynchronous events in Waku
 pub fn waku_set_event_callback<F: FnMut(Event) + Send + Sync>(ctx: &WakuNodeContext, mut f: F) {
     let cb = |response: LibwakuResponse| {
-        match response {
-            LibwakuResponse::Success(v) => {
-                let data: Event =
-                    serde_json::from_str(v.unwrap().as_str()).expect("Parsing event to succeed");
-                f(data);
-            }
-            _ => {} // Do nothing
+        if let LibwakuResponse::Success(v) = response {
+            let data: Event =
+                serde_json::from_str(v.unwrap().as_str()).expect("Parsing event to succeed");
+            f(data);
         };
     };
 

--- a/waku-bindings/src/node/mod.rs
+++ b/waku-bindings/src/node/mod.rs
@@ -14,7 +14,7 @@ pub use secp256k1::{PublicKey, SecretKey};
 use std::marker::PhantomData;
 use std::time::Duration;
 // internal
-use crate::general::{MessageId, Result, WakuMessage};
+use crate::general::{MessageHash, Result, WakuMessage};
 use context::WakuNodeContext;
 
 pub use config::WakuNodeConfig;
@@ -97,7 +97,7 @@ impl WakuNodeHandle<Running> {
         message: &WakuMessage,
         pubsub_topic: &String,
         timeout: Option<Duration>,
-    ) -> Result<MessageId> {
+    ) -> Result<MessageHash> {
         relay::waku_relay_publish_message(&self.ctx, message, pubsub_topic, timeout)
     }
 

--- a/waku-bindings/src/node/mod.rs
+++ b/waku-bindings/src/node/mod.rs
@@ -13,7 +13,7 @@ pub use multiaddr::Multiaddr;
 pub use secp256k1::{PublicKey, SecretKey};
 use std::time::Duration;
 // internal
-use crate::general::{Result, WakuMessage};
+use crate::general::{MessageId, Result, WakuMessage};
 use context::WakuNodeContext;
 
 pub use config::WakuNodeConfig;
@@ -26,6 +26,15 @@ pub struct WakuNodeHandle {
 }
 
 impl WakuNodeHandle {
+    /// Spawn a new Waku node with the given configuration (default configuration if `None` provided)
+    /// as per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_newchar-jsonconfig)
+    pub fn new(config: Option<WakuNodeConfig>) -> Result<WakuNodeHandle> {
+        Ok(WakuNodeHandle {
+            ctx: management::waku_new(config)?,
+        })
+    }
+
+
     /// Start a Waku node mounting all the protocols that were enabled during the Waku node instantiation.
     /// as per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_start)
     pub fn start(&self) -> Result<()> {
@@ -66,7 +75,7 @@ impl WakuNodeHandle {
         message: &WakuMessage,
         pubsub_topic: &String,
         timeout: Option<Duration>,
-    ) -> Result<()> {
+    ) -> Result<MessageId> {
         relay::waku_relay_publish_message(&self.ctx, message, pubsub_topic, timeout)
     }
 
@@ -83,12 +92,4 @@ impl WakuNodeHandle {
     pub fn set_event_callback<F: FnMut(Event) + Send + Sync + 'static>(&self, f: F) {
         events::waku_set_event_callback(&self.ctx, f)
     }
-}
-
-/// Spawn a new Waku node with the given configuration (default configuration if `None` provided)
-/// as per the [specification](https://rfc.vac.dev/spec/36/#extern-char-waku_newchar-jsonconfig)
-pub fn waku_new(config: Option<WakuNodeConfig>) -> Result<WakuNodeHandle> {
-    Ok(WakuNodeHandle {
-        ctx: management::waku_new(config)?,
-    })
 }

--- a/waku-bindings/src/node/relay.rs
+++ b/waku-bindings/src/node/relay.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 // crates
 use libc::*;
 // internal
-use crate::general::{Encoding, MessageId, Result, WakuContentTopic, WakuMessage};
+use crate::general::{Encoding, MessageHash, Result, WakuContentTopic, WakuMessage};
 use crate::node::context::WakuNodeContext;
 use crate::utils::{get_trampoline, handle_no_response, handle_response, LibwakuResponse};
 
@@ -62,7 +62,7 @@ pub fn waku_relay_publish_message(
     message: &WakuMessage,
     pubsub_topic: &String,
     timeout: Option<Duration>,
-) -> Result<MessageId> {
+) -> Result<MessageHash> {
     let pubsub_topic = pubsub_topic.to_string();
 
     let message_ptr = CString::new(

--- a/waku-bindings/src/node/relay.rs
+++ b/waku-bindings/src/node/relay.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 // crates
 use libc::*;
 // internal
-use crate::general::{Encoding, Result, WakuContentTopic, WakuMessage};
+use crate::general::{Encoding, MessageId, Result, WakuContentTopic, WakuMessage};
 use crate::node::context::WakuNodeContext;
 use crate::utils::{get_trampoline, handle_no_response, handle_response, LibwakuResponse};
 
@@ -62,7 +62,7 @@ pub fn waku_relay_publish_message(
     message: &WakuMessage,
     pubsub_topic: &String,
     timeout: Option<Duration>,
-) -> Result<()> {
+) -> Result<MessageId> {
     let pubsub_topic = pubsub_topic.to_string();
 
     let message_ptr = CString::new(
@@ -102,7 +102,7 @@ pub fn waku_relay_publish_message(
         out
     };
 
-    handle_no_response(code, result)
+    handle_response(code, result)
 }
 
 pub fn waku_relay_subscribe(ctx: &WakuNodeContext, pubsub_topic: &String) -> Result<()> {

--- a/waku-bindings/src/utils.rs
+++ b/waku-bindings/src/utils.rs
@@ -22,7 +22,10 @@ impl TryFrom<(u32, &str)> for LibwakuResponse {
         let opt_value = Some(response.to_string()).filter(|s| !s.is_empty());
         match ret_code {
             RET_OK => Ok(LibwakuResponse::Success(opt_value)),
-            RET_ERR => Ok(LibwakuResponse::Failure(format!("waku error: {}", response))),
+            RET_ERR => Ok(LibwakuResponse::Failure(format!(
+                "waku error: {}",
+                response
+            ))),
             RET_MISSING_CALLBACK => Ok(LibwakuResponse::MissingCallback),
             _ => Err(format!("undefined return code {}", ret_code)),
         }
@@ -98,7 +101,7 @@ pub fn handle_response<F: FromStr>(code: i32, result: LibwakuResponse) -> Result
         LibwakuResponse::Success(v) => v
             .unwrap_or_default()
             .parse()
-            .map_err(|_| format!("could not parse value")),
+            .map_err(|_| "could not parse value".into()),
         LibwakuResponse::Failure(v) => Err(v),
         LibwakuResponse::MissingCallback => panic!("callback is required"),
         LibwakuResponse::Undefined => panic!(


### PR DESCRIPTION
Changes:
- Instead of using `waku_new`, we use a constructor function.
- Takes into account the missing messageID I added in https://github.com/waku-org/nwaku/pull/2485