### PR TITLE
Makefile should be added to allow building libwaku when cargo publish

### DIFF
--- a/waku-sys/Cargo.toml
+++ b/waku-sys/Cargo.toml
@@ -18,14 +18,12 @@ exclude = [
     "vendor/docs/*",
     "vendor/coverage/*",
     "vendor/pkg/*",
-    "vendor/scripts/*",
     "vendor/tests/*",
     "vendor/ci/*",
     "vendor/cmd/*",
     "**/*.md",
     "**/*.lock",
     "**/*.nix",
-    "**/Makefile",
     "**/Dockerfile",
 ]
 


### PR DESCRIPTION
Also, scripts folder is needed to build rln

The issue was found while performing `cargo package` or `cargo publish` within the `waku-sys` folder.