### PR TITLE
Adapt for nwaku v0.35

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4945,7 +4945,7 @@ checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "waku-bindings"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "aes-gcm",
  "base64 0.21.7",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/waku-bindings/src/general/messagehash.rs
+++ b/waku-bindings/src/general/messagehash.rs
@@ -1,40 +1,18 @@
 use crate::general::waku_decode::WakuDecode;
-use hex::FromHex;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use std::fmt;
-use std::fmt::Write;
 use std::hash::Hash;
 use std::str::FromStr;
 
 /// Waku message hash, hex encoded sha256 digest of the message
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone, Hash)]
-pub struct MessageHash([u8; 32]);
-
-impl MessageHash {
-    fn to_hex_string(&self) -> String {
-        self.0.iter().fold(String::new(), |mut output, b| {
-            let _ = write!(output, "{b:02X}");
-            output
-        })
-    }
-}
+pub struct MessageHash(String);
 
 impl FromStr for MessageHash {
     type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        let s = s.strip_prefix("0x").unwrap_or(s);
-        // Decode the hexadecimal string to a Vec<u8>
-        // We expect a string format like: d38220de82fbcf2df865b680692fce98c36600fdd1d954b8a71e916dc4222b8e
-        let bytes = Vec::from_hex(s).map_err(|e| format!("Hex decode error MessageHash: {}", e))?;
-
-        // Ensure the length is exactly 32 bytes
-        let res = bytes
-            .try_into()
-            .map_err(|_| "Hex string must represent exactly 32 bytes".to_string())?;
-
-        Ok(MessageHash(res))
+        Ok(MessageHash(s.to_string()))
     }
 }
 
@@ -47,6 +25,6 @@ impl WakuDecode for MessageHash {
 // Implement the Display trait
 impl fmt::Display for MessageHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_hex_string())
+        write!(f, "{}", self.0)
     }
 }

--- a/waku-bindings/src/node/events.rs
+++ b/waku-bindings/src/node/events.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn deserialize_message_event() {
-        let s = "{\"eventType\":\"message\",\"messageHash\":[91, 70, 26, 8, 141, 232, 150, 200, 26, 206, 224, 175, 249, 74, 61, 140, 231, 126, 224, 160, 91, 80, 162, 65, 250, 171, 84, 149, 133, 110, 214, 101],\"pubsubTopic\":\"/waku/2/default-waku/proto\",\"wakuMessage\":{\"payload\":\"SGkgZnJvbSDwn6aAIQ==\",\"contentTopic\":\"/toychat/2/huilong/proto\",\"timestamp\":1665580926660}}";
+        let s = "{\"eventType\":\"message\",\"messageHash\":\"0xd40aa51bbb4867fe40329a255575cfc9ef4000358cc7321b2668b008cba94b30\",\"pubsubTopic\":\"/waku/2/default-waku/proto\",\"wakuMessage\":{\"payload\":\"SGkgZnJvbSDwn6aAIQ==\",\"contentTopic\":\"/toychat/2/huilong/proto\",\"timestamp\":1665580926660}}";
         let evt: WakuEvent = serde_json::from_str(s).unwrap();
         assert!(matches!(evt, WakuEvent::WakuMessage(_)));
     }

--- a/waku-sys/build.rs
+++ b/waku-sys/build.rs
@@ -9,7 +9,7 @@ fn submodules_init(project_dir: &Path) {
     let mark_file_path = ".submodules-initialized";
 
     // Check if the mark file exists
-    if !Path::new(&mark_file_path).exists() {
+    if !Path::new(mark_file_path).exists() {
         // If mark file doesn't exist, initialize submodule
         if Command::new("git")
             .args(["submodule", "init"])
@@ -32,7 +32,7 @@ fn submodules_init(project_dir: &Path) {
                 .expect("Failed to execute 'make update'")
                 .success()
             {
-                std::fs::File::create(&mark_file_path).expect("Failed to create mark file");
+                std::fs::File::create(mark_file_path).expect("Failed to create mark file");
             } else {
                 panic!("Failed to run 'make update' within nwaku folder.");
             }

--- a/waku-sys/build.rs
+++ b/waku-sys/build.rs
@@ -53,7 +53,7 @@ fn build_nwaku_lib(project_dir: &Path) {
     set_current_dir(vendor_path).expect("Moving to vendor dir");
 
     let mut cmd = Command::new("make");
-    cmd.arg("libwaku").arg("STATIC=true");
+    cmd.arg("libwaku").arg("STATIC=1");
     cmd.status()
         .map_err(|e| println!("cargo:warning=make build failed due to: {e}"))
         .unwrap();

--- a/waku-sys/build.rs
+++ b/waku-sys/build.rs
@@ -23,8 +23,8 @@ fn submodules_init(project_dir: &Path) {
                 .success()
         {
             // Now, inside nwaku folder, run 'make update' to get nwaku's vendors
-            let vendor_path = project_dir.join("vendor");
-            set_current_dir(vendor_path).expect("Moving to vendor dir");
+            let nwaku_path = project_dir.join("vendor");
+            set_current_dir(nwaku_path).expect("Moving to vendor dir");
 
             if Command::new("make")
                 .args(["update"])
@@ -49,8 +49,8 @@ fn submodules_init(project_dir: &Path) {
 }
 
 fn build_nwaku_lib(project_dir: &Path) {
-    let vendor_path = project_dir.join("vendor");
-    set_current_dir(vendor_path).expect("Moving to vendor dir");
+    let nwaku_path = project_dir.join("vendor");
+    set_current_dir(nwaku_path).expect("Moving to vendor dir");
 
     let mut cmd = Command::new("make");
     cmd.arg("libwaku").arg("STATIC=1");
@@ -62,12 +62,12 @@ fn build_nwaku_lib(project_dir: &Path) {
 }
 
 fn generate_bindgen_code(project_dir: &Path) {
-    let vendor_path = project_dir.join("vendor");
-    let header_path = vendor_path.join("library/libwaku.h");
+    let nwaku_path = project_dir.join("vendor");
+    let header_path = nwaku_path.join("library/libwaku.h");
 
     cc::Build::new()
         .object(
-            vendor_path
+            nwaku_path
                 .join("vendor/nim-libbacktrace/libbacktrace_wrapper.o")
                 .display()
                 .to_string(),
@@ -77,13 +77,13 @@ fn generate_bindgen_code(project_dir: &Path) {
     println!("cargo:rerun-if-changed={}", header_path.display());
     println!(
         "cargo:rustc-link-search={}",
-        vendor_path.join("build").display()
+        nwaku_path.join("build").display()
     );
     println!("cargo:rustc-link-lib=static=waku");
 
     println!(
         "cargo:rustc-link-search={}",
-        vendor_path
+        nwaku_path
             .join("vendor/nim-nat-traversal/vendor/miniupnp/miniupnpc/build")
             .display()
     );
@@ -91,7 +91,7 @@ fn generate_bindgen_code(project_dir: &Path) {
 
     println!(
         "cargo:rustc-link-search={}",
-        vendor_path
+        nwaku_path
             .join("vendor/nim-nat-traversal/vendor/libnatpmp-upstream")
             .display()
     );
@@ -102,7 +102,7 @@ fn generate_bindgen_code(project_dir: &Path) {
 
     println!(
         "cargo:rustc-link-search=native={}",
-        vendor_path
+        nwaku_path
             .join("vendor/nim-libbacktrace/install/usr/lib")
             .display()
     );


### PR DESCRIPTION
- bump waku-sys/vendor (nwaku) to v0.35.0
- adapt `waku-bindings/src/general/messagehash.rs` so that we handle waku message hashes as strings instead of byte[32]
- adapt `waku-sys/build.rs` so that the submodule is automatically initialized once and adapt to new parameter usage in nwaku's Makefile

### Issue
- https://github.com/waku-org/waku-rust-bindings/issues/106