### PR TITLE
ci: build and release pre-compiled libwaku artifacts

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,77 @@
+name: Release libwaku artifacts
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux-x86_64:
+    name: Build libwaku (Linux x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential git libpcre3-dev libssl-dev pkg-config
+      - name: Initialize vendor dependencies
+        run: cd waku-sys/vendor && make update
+      - name: Build libwaku
+        run: cd waku-sys/vendor && make libwaku STATIC=0 MAKEFLAGS="-j$(nproc)"
+      - name: Prepare artifact
+        run: cp waku-sys/vendor/build/libwaku.so libwaku-linux-x86_64.so
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: libwaku-linux-x86_64.so
+
+  build-linux-arm64:
+    name: Build libwaku (Linux ARM64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential git libpcre3-dev libssl-dev pkg-config
+      - name: Initialize vendor dependencies
+        run: cd waku-sys/vendor && make update
+      - name: Build libwaku
+        run: cd waku-sys/vendor && make libwaku STATIC=0 MAKEFLAGS="-j$(nproc)"
+      - name: Prepare artifact
+        run: cp waku-sys/vendor/build/libwaku.so libwaku-linux-arm64.so
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: libwaku-linux-arm64.so
+
+  build-macos-arm64:
+    name: Build libwaku (macOS ARM64)
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: brew install pcre openssl@3 pkg-config
+      - name: Initialize vendor dependencies
+        run: cd waku-sys/vendor && make update
+      - name: Build libwaku
+        run: cd waku-sys/vendor && make libwaku STATIC=0 MAKEFLAGS="-j$(sysctl -n hw.ncpu)"
+      - name: Prepare artifact
+        run: cp waku-sys/vendor/build/libwaku.dylib libwaku-macos-arm64.dylib
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: libwaku-macos-arm64.dylib

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ Rust layer on top of [`logos-messaging-nim`](https://github.com/logos-messaging/
 Private. Secure. Runs anywhere.
 
 Read the [Waku docs](https://docs.waku.org/)
+
+## Pre-built libwaku artifacts
+
+Pre-compiled `libwaku` shared libraries are available as GitHub Release assets for each tagged version:
+
+| Platform | Artifact |
+|----------|----------|
+| Linux x86_64 | `libwaku-linux-x86_64.so` |
+| Linux ARM64 | `libwaku-linux-arm64.so` |
+| macOS ARM64 | `libwaku-macos-arm64.dylib` |
+
+Download them from the [Releases](https://github.com/logos-messaging/logos-delivery-rust-bindings/releases) page.


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`release-artifacts.yml`) to build and release pre-compiled `libwaku` shared libraries on tagged releases (`v*`)
- Build targets: Linux x86_64 (`.so`), Linux ARM64 (`.so`), macOS ARM64 (`.dylib`)
- Update README with a table listing available pre-built artifacts and link to releases page

Closes #128

## Test plan
- [ ] Push a `v*` tag to trigger the workflow
- [ ] Verify all three jobs complete successfully (Linux x86_64, Linux ARM64, macOS ARM64)
- [ ] Verify artifacts are uploaded to the GitHub Release with correct names
- [ ] Download each artifact and verify it is a valid shared library (`file libwaku-*.so`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)